### PR TITLE
Update eslint rules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+save-exact=true

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
-import eslintConfigPrettier from 'eslint-config-prettier'
+import eslintConfigPrettier from 'eslint-config-prettier/flat'
 import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 //import eslintPluginTailwindcss from 'eslint-plugin-tailwindcss'
@@ -27,16 +27,16 @@ export default [
   },
   {
     name: 'ignore settings',
-    ignores: ['dist/*', '*.config.{js,ts}', 'node_modules/*'],
+    ignores: ['dist/*', '*.config.{js,ts}'],
   },
   // ==========================================
   // 標準設定 (推奨設定を活用)
   // ==========================================
-  js.configs.recommended,
+  { name: '@eslint/js', ...js.configs.recommended },
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
-  eslintPluginReact.configs.flat.recommended,
-  eslintPluginReact.configs.flat['jsx-runtime'],
+  { name: 'react', ...eslintPluginReact.configs.flat.recommended },
+  { name: 'react-jsx', ...eslintPluginReact.configs.flat['jsx-runtime'] },
   eslintPluginReactHooks.configs['recommended-latest'],
   // eslintPluginTailwindcss.configs.recommended,
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,39 +4,79 @@ import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
+//import eslintPluginTailwindcss from 'eslint-plugin-tailwindcss'
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
-  {
-    name: 'ignore files',
-    ignores: ['dist/*', '*.config.{js,ts}'],
-  },
+  // ==========================================
+  // ベース設定
+  // ==========================================
   {
     name: 'global settings',
     languageOptions: {
       parser: tseslint.parser,
       globals: { ...globals.browser },
-      parserOptions: { project: './tsconfig.json' },
+      parserOptions: {
+        project: './tsconfig.json',
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
     },
     linterOptions: { reportUnusedDisableDirectives: 'error' },
     settings: { react: { version: 'detect' } },
+    ignores: ['dist/*', '*.config.{js,ts}', 'node_modules/*'],
   },
+
+  // ==========================================
+  // 標準設定 (推奨設定を活用)
+  // ==========================================
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],
   eslintPluginReactHooks.configs['recommended-latest'],
-  eslintConfigPrettier,
+  // eslintPluginTailwindcss.configs.recommended,
+
+  // ==========================================
+  // 推奨設定にないカスタムルール
+  // ==========================================
   {
-    name: 'Type Importを強制するRules',
+    name: 'custom rules',
     rules: {
+      // React 関連の追加ルール
+      'react/jsx-no-target-blank': 'error',
+      'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
+      'react/self-closing-comp': 'error',
+
+      // 型インポートに関するルール
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-import-type-side-effects': 'error',
+
+      // コード品質に関するルール
+      'no-console': 'warn',
+      'no-debugger': 'warn',
+      'no-alert': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      'prefer-const': 'error',
+      'no-var': 'error',
+      'eqeqeq': ['error', 'always', { null: 'ignore' }],
     },
   },
+
+  // ==========================================
+  // 一時的に無効化したルール
+  // ==========================================
   {
-    name: '一時的にOFFにしたRules',
+    name: '一時的に無効化したルール',
     rules: {},
   },
+
+  // ==========================================
+  // Prettier (他の設定を上書きするため最後に配置)
+  // ==========================================
+  eslintConfigPrettier,
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,13 +54,6 @@ export default [
       '@typescript-eslint/no-import-type-side-effects': 'error',
 
       // コード品質に関するルール
-      'no-console': 'warn',
-      'no-debugger': 'warn',
-      'no-alert': 'warn',
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
-        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-      ],
       'prefer-const': 'error',
       'no-var': 'error',
       'eqeqeq': ['error', 'always', { null: 'ignore' }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,9 +24,11 @@ export default [
     },
     linterOptions: { reportUnusedDisableDirectives: 'error' },
     settings: { react: { version: 'detect' } },
+  },
+  {
+    name: 'ignore settings',
     ignores: ['dist/*', '*.config.{js,ts}', 'node_modules/*'],
   },
-
   // ==========================================
   // 標準設定 (推奨設定を活用)
   // ==========================================


### PR DESCRIPTION
設定を追加したりinspectorで見やすくしました。


This pull request includes updates to the `.npmrc` and `eslint.config.js` files to enforce stricter rules and improve configuration clarity. The key changes involve setting strict rules for npm and reordering and enhancing ESLint configurations.

NPM configuration updates:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1-R2): Enforced strict engine version and exact version saving for dependencies.

ESLint configuration improvements:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L4-R76): Updated the import path for `eslint-config-prettier` to use the flat configuration.
* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L4-R76): Reorganized the configuration sections for better clarity, including adding comments and renaming sections to be more descriptive.
* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L4-R76): Added new custom rules for React and TypeScript, as well as code quality rules such as enforcing `prefer-const`, `no-var`, and `eqeqeq`.
* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L4-R76): Temporarily disabled certain rules and added placeholders for future custom rules.