### PR TITLE
Refactor linting scripts for better organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
     "lint:types": "tsc --noEmit",
-    "lint:fix": "npm run lint:eslint:fix && npm run lint:prettier:format",
+    "lint:fix": "npm run lint:eslint:fix && npm run lint:prettier:fix",
     "lint:eslint:fix": "eslint . --fix",
-    "lint:prettier:format": "prettier --write .",
+    "lint:prettier:fix": "prettier --write .",
     "test": "vitest run",
     "preview": "vite preview"
   },

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . && prettier --check .",
-    "lint:fix": "eslint . --fix",
-    "lint:format": "prettier --write .",
-    "test": "npm run lint && tsc --noEmit && npm run vitest",
-    "preview": "vite preview",
-    "vitest": "vitest run"
+    "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",
+    "lint:eslint": "eslint .",
+    "lint:prettier": "prettier --check .",
+    "lint:types": "tsc --noEmit",
+    "lint:fix": "npm run lint:eslint:fix && npm run lint:prettier:format",
+    "lint:eslint:fix": "eslint . --fix",
+    "lint:prettier:format": "prettier --write .",
+    "test": "vitest run",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "19.1.0",


### PR DESCRIPTION
This pull request refactors the `scripts` section in the `package.json` file to modularize linting tasks and simplify the testing workflow.

Key changes:

### Script modularization:
* Split the `lint` script into three separate scripts: `lint:eslint`, `lint:prettier`, and `lint:types`, each handling a specific aspect of linting.
* Introduced `lint:fix` as a composite script that runs `lint:eslint:fix` and `lint:prettier:fix` for fixing linting and formatting issues.

### Testing workflow simplification:
* Updated the `test` script to directly run `vitest` instead of including linting and type-checking as prerequisites.